### PR TITLE
feat: video thumbnail preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +989,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,7 +1062,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -1052,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1960,6 +1998,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ffmpeg-next"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da02698288e0275e442a47fc12ca26d50daf0d48b15398ba5906f20ac2e2a9f9"
+dependencies = [
+ "bitflags 2.9.1",
+ "ffmpeg-sys-next",
+ "libc",
+]
+
+[[package]]
+name = "ffmpeg-sys-next"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e9c75ebd4463de9d8998fb134ba26347fe5faee62fabf0a4b4d41bd500b4ad"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "num_cpus",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "file_type"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2373,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globalcache"
@@ -3242,6 +3311,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "video-rs",
  "zip 4.3.0",
 ]
 
@@ -3493,6 +3563,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3737,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3814,6 +3909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,6 +3962,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.1",
+ "libc",
 ]
 
 [[package]]
@@ -4765,6 +4879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5115,6 +5238,12 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -6611,6 +6740,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "video-rs"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f6df3b49d862ea35d2c509801ee64983f2169ea02e3a8642e69ce2230e47c"
+dependencies = [
+ "ffmpeg-next",
+ "ndarray",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "vte"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7084,7 +7225,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ bzip2 = "0.6"
 image = { version = "0" }
 kamadak-exif = "0"
 
+# video handling
+video-rs = { version = "0.10", features = ["ndarray"] }
+
 # for pdf rendering
 pdf_render = { git = "https://github.com/houqp/pdf_render.git", rev = "00b907936e45d904f958197fa6039320d0ac098d", features = [
     "embed",

--- a/src/models/preview_content.rs
+++ b/src/models/preview_content.rs
@@ -84,6 +84,34 @@ impl std::fmt::Debug for ImageMeta {
     }
 }
 
+/// Metadata for video files
+#[derive(Clone)]
+pub struct VideoMeta {
+    /// Video title (usually filename)
+    pub title: String,
+    /// Video metadata (key-value pairs)
+    pub metadata: HashMap<String, String>,
+    /// Video thumbnail image
+    pub thumbnail: egui::widgets::ImageSource<'static>,
+    /// Keep the texture handle alive to prevent GPU texture from being freed
+    pub _texture_handle: Option<egui::TextureHandle>,
+}
+
+// Manual implementation of Debug for VideoMeta since TextureHandle doesn't implement Debug
+impl std::fmt::Debug for VideoMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VideoMeta")
+            .field("title", &self.title)
+            .field("metadata", &self.metadata)
+            .field("thumbnail", &"ImageSource")
+            .field(
+                "_texture_handle",
+                &self._texture_handle.as_ref().map(|_| "TextureHandle"),
+            )
+            .finish()
+    }
+}
+
 /// Represents different types of preview content that can be displayed in the right panel
 #[derive(Clone, Debug)]
 pub enum PreviewContent {
@@ -91,6 +119,8 @@ pub enum PreviewContent {
     Text(String),
     /// Image content with metadata
     Image(ImageMeta),
+    /// Video content with metadata and thumbnail
+    Video(VideoMeta),
     /// Zip file content with a list of entries
     Zip(Vec<ZipEntry>),
     /// Tar file content with a list of entries (supports both compressed and uncompressed)
@@ -173,6 +203,20 @@ impl PreviewContent {
             exif_data,
             image_source: egui::widgets::ImageSource::Uri(uri.into()),
             _texture_handle: None, // No texture handle for URI-based images//
+        })
+    }
+
+    /// Creates a new video preview content with a texture handle for thumbnail
+    pub fn video(
+        title: impl Into<String>,
+        metadata: HashMap<String, String>,
+        texture: egui::TextureHandle,
+    ) -> Self {
+        Self::Video(VideoMeta {
+            title: title.into(),
+            metadata,
+            thumbnail: egui::widgets::ImageSource::from(&texture),
+            _texture_handle: Some(texture),
         })
     }
 

--- a/src/ui/popup/preview/mod.rs
+++ b/src/ui/popup/preview/mod.rs
@@ -10,6 +10,7 @@ use egui_extras::syntax_highlighting::{self, CodeTheme};
 
 pub mod doc;
 pub mod image;
+pub mod video;
 
 /// Handle the `ShowFilePreview` shortcut action
 /// This function was extracted from input.rs to reduce complexity
@@ -95,6 +96,10 @@ pub fn handle_show_file_preview(app: &mut Kiorg, _ctx: &egui::Context) {
         }
         crate::ui::preview::image_extensions!() => {
             // Show preview popup for image files
+            app.show_popup = Some(PopupType::Preview);
+        }
+        crate::ui::preview::video_extensions!() => {
+            // Show preview popup for video files
             app.show_popup = Some(PopupType::Preview);
         }
         ext if crate::ui::preview::text::lang_type_from_ext(ext).is_some() => {
@@ -187,6 +192,16 @@ pub fn show_preview_popup(ctx: &Context, app: &mut Kiorg) {
                             image::render_popup(
                                 ui,
                                 image_meta,
+                                &app.colors,
+                                available_width,
+                                available_height,
+                            );
+                        }
+                        PreviewContent::Video(video_meta) => {
+                            // Use specialized popup video renderer
+                            video::render_popup(
+                                ui,
+                                video_meta,
                                 &app.colors,
                                 available_width,
                                 available_height,

--- a/src/ui/popup/preview/video.rs
+++ b/src/ui/popup/preview/video.rs
@@ -1,0 +1,46 @@
+  //! Video preview module for popup display
+
+  use crate::config::colors::AppColors;
+  use crate::models::preview_content::VideoMeta;
+  use egui::{Image, RichText};
+
+  /// Render video content optimized for popup view
+  ///
+  /// This version focuses on displaying the video thumbnail at a large size
+  pub fn render_popup(
+      ui: &mut egui::Ui,
+      video_meta: &VideoMeta,
+      colors: &AppColors,
+      available_width: f32,
+      available_height: f32,
+  ) {
+      // Use a layout that maximizes thumbnail space
+      ui.vertical_centered(|ui| {
+          ui.add_space(5.0);
+
+          // Use most available space for the thumbnail
+          let max_height = available_height * 0.90;
+          let max_width = available_width * 0.90;
+
+          // Add the video thumbnail with maximum possible size
+          ui.add(
+              Image::new(video_meta.thumbnail.clone())
+                  .max_size(egui::vec2(max_width, max_height))
+                  .maintain_aspect_ratio(true),
+          );
+
+          ui.add_space(10.0);
+          
+          // Show duration if available
+          if let Some(duration) = video_meta.metadata.get("Duration") {
+              ui.label(RichText::new(format!("Duration: {duration}")).color(colors.fg).size(14.0));
+          }
+          
+          // Show dimensions if available
+          if let Some(dimensions) = video_meta.metadata.get("Dimensions") {
+              ui.label(RichText::new(format!("Resolution: {dimensions}")).color(colors.fg_light).size(12.0));
+          }
+          
+          ui.add_space(5.0);
+      });
+  }

--- a/src/ui/preview/mod.rs
+++ b/src/ui/preview/mod.rs
@@ -6,6 +6,7 @@ pub mod image;
 pub mod loading;
 pub mod tar;
 pub mod text;
+pub mod video;
 pub mod zip;
 
 use crate::app::Kiorg;
@@ -62,6 +63,13 @@ macro_rules! image_extensions {
 }
 
 #[macro_export]
+macro_rules! video_extensions {
+    () => {
+        "mp4" | "m4v" | "mkv" | "webm" | "mov" | "avi" | "wmv" | "mpg" | "flv"
+    };
+}
+
+#[macro_export]
 macro_rules! zip_extensions {
     () => {
         "zip" | "jar" | "war" | "ear"
@@ -92,6 +100,7 @@ macro_rules! epub_extensions {
 // Public macros for use in other modules
 pub use epub_extensions;
 pub use image_extensions;
+pub use video_extensions;
 pub use pdf_extensions;
 pub use tar_extensions;
 pub use zip_extensions;
@@ -145,6 +154,12 @@ pub fn update_cache(app: &mut Kiorg, ctx: &egui::Context) {
             let ctx_clone = ctx.clone();
             loading::load_preview_async(app, entry.path, move |path| {
                 image::read_image_with_metadata(&path, &ctx_clone)
+            });
+        }
+        video_extensions!() => {
+            let ctx_clone = ctx.clone();
+            loading::load_preview_async(app, entry.path, move |path| {
+                video::read_video_with_metadata(&path, &ctx_clone)
             });
         }
         zip_extensions!() => {

--- a/src/ui/preview/video.rs
+++ b/src/ui/preview/video.rs
@@ -1,0 +1,236 @@
+//! Video preview module
+
+use crate::config::colors::AppColors;
+use crate::models::preview_content::{VideoMeta, PreviewContent};
+use egui::{Image, RichText};
+use std::collections::HashMap;
+use std::path::Path;
+use video_rs::decode::Decoder;
+use video_rs::Url;
+
+const METADATA_KEY_COLUMN_WIDTH: f32 = 100.0;
+
+/// Render video content
+pub fn render(
+    ui: &mut egui::Ui,
+    video_meta: &VideoMeta,
+    colors: &AppColors,
+    available_width: f32,
+    available_height: f32,
+) {
+    // Display video title
+    ui.label(
+        RichText::new(&video_meta.title)
+            .color(colors.fg)
+            .strong()
+            .size(20.0),
+    );
+    ui.add_space(10.0);
+
+    // Display video thumbnail (centered)
+    ui.vertical_centered(|ui| {
+        ui.add(
+            Image::new(video_meta.thumbnail.clone())
+                .max_size(egui::vec2(available_width, available_height * 0.6))
+                .maintain_aspect_ratio(true),
+        );
+    });
+    ui.add_space(15.0);
+
+    // Create a table for video metadata
+    ui.label(
+        RichText::new("Video Metadata")
+            .color(colors.fg_folder)
+            .strong()
+            .size(14.0),
+    );
+    ui.add_space(5.0);
+
+    egui::Grid::new("video_metadata_grid")
+        .num_columns(2)
+        .spacing([10.0, 6.0])
+        .striped(true)
+        .show(ui, |ui| {
+            // Sort keys for consistent display
+            let mut sorted_keys: Vec<&String> = video_meta.metadata.keys().collect();
+            sorted_keys.sort();
+
+            // Display each metadata field in a table row
+            for key in sorted_keys {
+                if let Some(value) = video_meta.metadata.get(key) {
+                    ui.with_layout(egui::Layout::left_to_right(egui::Align::LEFT), |ui| {
+                        ui.set_min_width(METADATA_KEY_COLUMN_WIDTH);
+                        ui.set_max_width(METADATA_KEY_COLUMN_WIDTH);
+                        ui.add(egui::Label::new(RichText::new(key).color(colors.fg)).wrap());
+                    });
+                    ui.add(egui::Label::new(RichText::new(value).color(colors.fg)).wrap());
+                    ui.end_row();
+                }
+            }
+        });
+}
+
+/// Read video file, extract metadata and generate thumbnail, and create a `PreviewContent`
+pub fn read_video_with_metadata(
+    path: &Path,
+    ctx: &egui::Context,
+) -> Result<PreviewContent, String> {
+    // Get the filename for the title
+    let title = path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    // Create a HashMap to store metadata
+    let mut metadata = HashMap::new();
+
+    // Add file size
+    if let Ok(file_metadata) = std::fs::metadata(path) {
+        let size = file_metadata.len();
+        metadata.insert(
+            "File Size".to_string(),
+            humansize::format_size(size, humansize::BINARY),
+        );
+    }
+
+    // Get file extension for file type information
+    if let Some(ext) = path.extension() {
+        let ext_str = ext.to_string_lossy().to_uppercase();
+        metadata.insert("File Type".to_string(), ext_str.to_string());
+    }
+
+    // Try to extract a real thumbnail from the video
+    let thumbnail_texture = match extract_video_thumbnail(ctx, path, &mut metadata) {
+        Ok(texture) => texture,
+        Err(_e) => {
+            // Fall back to placeholder thumbnail
+            generate_placeholder_thumbnail(ctx, path)
+                .map_err(|e| format!("Failed to generate thumbnail: {e}"))?
+        }
+    };
+
+    Ok(PreviewContent::video(title, metadata, thumbnail_texture))
+}
+
+/// Extract a thumbnail from the video file using video-rs
+fn extract_video_thumbnail(
+    ctx: &egui::Context,
+    path: &Path,
+    metadata: &mut HashMap<String, String>,
+) -> Result<egui::TextureHandle, String> {    
+    // Initialize video-rs (a wrapper for ffmpeg-next)
+    video_rs::init().map_err(|e| format!("Failed to initialize video-rs: {e}"))?;
+
+    // Convert path to URL format
+    let absolute_path = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to canonicalize path: {e}"))?;
+    let source = format!("file://{}", absolute_path.display())
+        .parse::<Url>()
+        .map_err(|e| format!("Failed to parse URL: {e}"))?;
+
+    // Create decoder
+    let mut decoder = Decoder::new(source)
+        .map_err(|e| format!("Failed to create decoder: {e}"))?;
+
+    // Get video dimensions and add to metadata
+    let (width, height) = decoder.size();
+    metadata.insert("Dimensions".to_string(), format!("{}x{}", width, height));
+
+    // Try to get duration information
+    if let Ok(duration) = decoder.duration() {
+        let total_seconds = duration.as_secs() as u64;
+        let hours = total_seconds / 3600;
+        let minutes = (total_seconds % 3600) / 60;
+        let seconds = total_seconds % 60;
+        
+        if hours > 0 {
+            metadata.insert("Duration".to_string(), format!("{}:{:02}:{:02}", hours, minutes, seconds));
+        } else {
+            metadata.insert("Duration".to_string(), format!("{}:{:02}", minutes, seconds));
+        }
+    }
+
+    // Decode the first frame
+    let (_, frame) = decoder
+        .decode()
+        .map_err(|e| format!("Failed to decode frame: {e}"))?;
+
+    // Convert frame to raw RGB data
+    let (raw, _) = frame.into_raw_vec_and_offset();
+
+    // Convert RGB to RGBA from raw data
+    let rgba_data: Vec<u8> = raw
+        .chunks_exact(3)
+        .flat_map(|rgb| [rgb[0], rgb[1], rgb[2], 255u8])
+        .collect();
+
+    // Create egui::ColorImage from the RGBA data
+    let color_image = egui::ColorImage::from_rgba_unmultiplied([width as _, height as _], &rgba_data);
+
+    // Create the texture with path-based ID for uniqueness
+    let texture_id = format!("video_thumbnail_{}", path.display());
+    let texture = ctx.load_texture(texture_id, color_image, egui::TextureOptions::default());
+
+    Ok(texture)
+}
+
+/// Generate a placeholder thumbnail for video files if extraction fails
+fn generate_placeholder_thumbnail(
+    ctx: &egui::Context,
+    path: &Path,
+) -> Result<egui::TextureHandle, String> {
+    let width = 320;
+    let height = 240;
+    
+    let mut rgb_data = Vec::with_capacity(width * height * 3);
+    
+    // Create a dark background with a play button symbol
+    for y in 0..height {
+        for x in 0..width {
+            // Create a dark gray background
+            let mut r = 40u8;
+            let mut g = 40u8;
+            let mut b = 40u8;
+            
+            // Add a border
+            if x < 2 || x >= width - 2 || y < 2 || y >= height - 2 {
+                r = 80;
+                g = 80;
+                b = 80;
+            }
+            
+            // Add a triangular play button in the center
+            let center_x = width / 2;
+            let center_y = height / 2;
+            let rel_x = x as i32 - center_x as i32;
+            let rel_y = y as i32 - center_y as i32;
+            
+            if rel_x >= -15 && rel_x <= 15 && rel_y.abs() <= 15 {
+                let max_y = if rel_x <= 0 {
+                    15
+                } else {
+                    15 - (rel_x * 15) / 15
+                };
+                
+                if rel_y.abs() <= max_y {
+                    r = 220;
+                    g = 220;
+                    b = 220;
+                }
+            }
+            
+            rgb_data.push(r);
+            rgb_data.push(g);
+            rgb_data.push(b);
+        }
+    }
+
+    // Create the texture
+    let color_image = egui::ColorImage::from_rgb([width, height], &rgb_data);
+    let texture_id = format!("video_placeholder_{}", path.display());
+    let texture = ctx.load_texture(texture_id, color_image, egui::TextureOptions::default());
+
+    Ok(texture)
+}

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -129,6 +129,15 @@ pub fn draw(app: &mut Kiorg, ctx: &egui::Context, ui: &mut Ui, width: f32, heigh
                                 available_height,
                             );
                         }
+                        Some(PreviewContent::Video(ref video_meta)) => {
+                            preview::video::render(
+                                ui,
+                                video_meta,
+                                colors,
+                                available_width,
+                                available_height,
+                            );
+                        }
                         Some(PreviewContent::Pdf(ref pdf_meta)) => {
                             preview::doc::render(
                                 ui,


### PR DESCRIPTION
Description:

This change introduces a thumbnail preview for videos. [video-rs](https://crates.io/crates/video-rs) (ffmpeg-next wrapper) is used to extract the raw RGB data of the first frame of the video. This is then converted into RGBA to create an `egui::ColorImage`. If the extraction fails (i.e. the video file is corrupted, empty, etc.), then a placeholder image is generated.

Before changes:
<img width="322" height="163" alt="image" src="https://github.com/user-attachments/assets/68579e5c-b35c-4742-b3ac-09f57e7e88c8" />

Previewing a video:
<img width="512" height="768" alt="image" src="https://github.com/user-attachments/assets/7b890900-519e-4520-83e2-66b2a8166b1d" />
<img width="1167" height="754" alt="image" src="https://github.com/user-attachments/assets/5c67b9df-f6aa-422e-8d02-4812a5a06cbc" />

When attempting to preview a corrupted file:
<img width="505" height="399" alt="image" src="https://github.com/user-attachments/assets/2411719c-ea17-4305-a273-88ead4e31a9a" />
