### PR TITLE
feat: allow configuration for default directory on app launch

### DIFF
--- a/crates/kiorg/src/app.rs
+++ b/crates/kiorg/src/app.rs
@@ -975,7 +975,7 @@ impl Kiorg {
 
                 // Verify that the saved path still exists
                 if path.exists() && path.is_dir() {
-                    return (tab_manager, path)
+                    return (tab_manager, path);
                 }
 
                 // If saved path doesn't exist, fall back to default directory
@@ -985,24 +985,27 @@ impl Kiorg {
                 );
             }
         }
-        
+
         // Use default directory if set
         if let Some(ref default_dir) = config.default_directory {
             let default_path = PathBuf::from(default_dir);
 
             // Verify that the path still exists
             if default_path.exists() && default_path.is_dir() {
-                let tab_manager = TabManager::new_with_config(default_path.clone(), Some(&config));
-                return (tab_manager, default_path)
+                let tab_manager = TabManager::new_with_config(default_path.clone(), Some(config));
+                return (tab_manager, default_path);
             }
-            
+
             // If default directory fails, use fallback directory
-            tracing::warn!("default_directory '{}' is invalid, falling back", default_dir);
+            tracing::warn!(
+                "default_directory '{}' is invalid, falling back",
+                default_dir
+            );
         }
 
         // Use fallback directory
         let fallback_path = fallback_initial_dir();
-        let tab_manager = TabManager::new_with_config(fallback_path.clone(), Some(&config));
+        let tab_manager = TabManager::new_with_config(fallback_path.clone(), Some(config));
         (tab_manager, fallback_path)
     }
 

--- a/crates/kiorg/src/app.rs
+++ b/crates/kiorg/src/app.rs
@@ -139,7 +139,9 @@ fn fallback_initial_dir() -> PathBuf {
 #[derive(Serialize, Deserialize)]
 pub struct AppState {
     pub tab_manager: TabManagerState,
-    // Add more fields here in the future
+    // Whether to restore previous session
+    #[serde(default)]
+    pub restore_session: bool,
 }
 
 pub struct Kiorg {
@@ -179,6 +181,8 @@ pub struct Kiorg {
     // Key buffer for tracking unprocessed key presses
     pub key_buffer: Vec<crate::config::shortcuts::ShortcutKey>,
     pub shutdown_requested: bool,
+    // Tracks whether to restore previous session
+    pub restore_session: bool,
     // Signal whether to scroll to display current directory in the left panel
     pub scroll_left_panel: bool,
     // Global visit history tracking
@@ -249,32 +253,7 @@ impl Kiorg {
                 (tab_manager, path)
             }
             // If no initial directory is provided, try to load from saved state
-            None => {
-                if let Some(tab_manager) = Self::load_app_state(config_dir_override.as_deref()) {
-                    // Use the saved state's path
-                    let path = tab_manager.current_tab_ref().current_path.clone();
-
-                    // Verify that the saved path still exists
-                    if !path.exists() || !path.is_dir() {
-                        // If saved path doesn't exist, fall back to home directory
-                        tracing::error!(
-                            "Saved path in state '{}' is invalid, falling back to home directory",
-                            path.display()
-                        );
-                        let fallback_path = fallback_initial_dir();
-                        let fallback_tab_manager =
-                            TabManager::new_with_config(fallback_path.clone(), Some(&config));
-                        (fallback_tab_manager, fallback_path)
-                    } else {
-                        (tab_manager, path)
-                    }
-                } else {
-                    // No saved state, use fallback directory
-                    let path = fallback_initial_dir();
-                    let tab_manager = TabManager::new_with_config(path.clone(), Some(&config));
-                    (tab_manager, path)
-                }
-            }
+            None => Self::load_initial_state(config_dir_override.as_deref(), &config),
         };
 
         let (fs_watcher, notify_fs_change) = match create_fs_watcher(initial_path.as_path()) {
@@ -332,6 +311,7 @@ impl Kiorg {
             key_buffer: Vec::new(),
             terminal_ctx: None,
             shutdown_requested: false,
+            restore_session: false,
             notify_fs_change,
             scroll_left_panel: false,
             fs_watcher,
@@ -961,6 +941,7 @@ impl Kiorg {
     }
 
     pub fn graceful_shutdown(&mut self) {
+        self.restore_session = true;
         self.history_saver.shutdown();
 
         // Shutdown plugins
@@ -980,6 +961,64 @@ impl Kiorg {
         crate::utils::preview_cache::purge_cache_dir();
     }
 
+    fn load_initial_state(
+        config_dir_override: Option<&std::path::Path>,
+        config: &config::Config,
+    ) -> (TabManager, PathBuf) {
+        if let Some((tab_manager, restore_session)) = Self::load_app_state(config_dir_override) {
+            // Reset restore session state flag
+            Self::reset_restore_session(config_dir_override);
+
+            if restore_session {
+                // Use the saved state's path
+                let path = tab_manager.current_tab_ref().current_path.clone();
+
+                // Verify that the saved path still exists
+                if path.exists() && path.is_dir() {
+                    return (tab_manager, path)
+                }
+
+                // If saved path doesn't exist, fall back to default directory
+                tracing::error!(
+                    "Saved path in state '{}' is invalid, falling back to default or home directory",
+                    path.display()
+                );
+            }
+        }
+        
+        // Use default directory if set
+        if let Some(ref default_dir) = config.default_directory {
+            let default_path = PathBuf::from(default_dir);
+
+            // Verify that the path still exists
+            if default_path.exists() && default_path.is_dir() {
+                let tab_manager = TabManager::new_with_config(default_path.clone(), Some(&config));
+                return (tab_manager, default_path)
+            }
+            
+            // If default directory fails, use fallback directory
+            tracing::warn!("default_directory '{}' is invalid, falling back", default_dir);
+        }
+
+        // Use fallback directory
+        let fallback_path = fallback_initial_dir();
+        let tab_manager = TabManager::new_with_config(fallback_path.clone(), Some(&config));
+        (tab_manager, fallback_path)
+    }
+
+    fn reset_restore_session(config_dir_override: Option<&std::path::Path>) {
+        let config_dir = config::get_kiorg_config_dir(config_dir_override);
+        let state_path = config_dir.join(STATE_FILE_NAME);
+        if let Ok(json_str) = std::fs::read_to_string(&state_path) {
+            if let Ok(mut app_state) = serde_json::from_str::<AppState>(&json_str) {
+                app_state.restore_session = false;
+                if let Ok(updated) = serde_json::to_string_pretty(&app_state) {
+                    let _ = std::fs::write(&state_path, updated);
+                }
+            }
+        }
+    }
+
     fn save_app_state(&self) -> Result<(), Box<dyn std::error::Error>> {
         let config_dir = config::get_kiorg_config_dir(self.config_dir_override.as_deref());
 
@@ -991,7 +1030,7 @@ impl Kiorg {
         let state_path = config_dir.join(STATE_FILE_NAME);
         let app_state = AppState {
             tab_manager: self.tab_manager.to_state(),
-            // Add more fields here in the future
+            restore_session: self.restore_session,
         };
         let state_json = serde_json::to_string_pretty(&app_state)?;
         std::fs::write(&state_path, state_json)?;
@@ -999,7 +1038,7 @@ impl Kiorg {
         Ok(())
     }
 
-    fn load_app_state(config_dir_override: Option<&std::path::Path>) -> Option<TabManager> {
+    fn load_app_state(config_dir_override: Option<&std::path::Path>) -> Option<(TabManager, bool)> {
         let config_dir = config::get_kiorg_config_dir(config_dir_override);
         let state_path = config_dir.join(STATE_FILE_NAME);
 
@@ -1012,9 +1051,11 @@ impl Kiorg {
                 // First try to parse as the new format (AppState)
                 match serde_json::from_str::<AppState>(&json_str) {
                     Ok(app_state) => {
+                        // Retrieve session restore state
+                        let restore_session = app_state.restore_session;
                         // Convert TabManagerState to TabManager
                         let tab_manager = TabManager::from_state(app_state.tab_manager);
-                        Some(tab_manager)
+                        Some((tab_manager, restore_session))
                     }
                     Err(_) => {
                         // If that fails, try the old format (direct TabManagerState)
@@ -1022,7 +1063,7 @@ impl Kiorg {
                             Ok(tab_manager_state) => {
                                 // Convert TabManagerState to TabManager
                                 let tab_manager = TabManager::from_state(tab_manager_state);
-                                Some(tab_manager)
+                                Some((tab_manager, false))
                             }
                             Err(e) => {
                                 eprintln!("Failed to parse app state: {e}");

--- a/crates/kiorg/src/config/mod.rs
+++ b/crates/kiorg/src/config/mod.rs
@@ -49,6 +49,7 @@ pub struct Layout {
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct Config {
     pub theme: Option<String>,
+    pub default_directory: Option<String>,
     pub sort_preference: Option<SortPreference>,
     pub shortcuts: Option<shortcuts::Shortcuts>,
     pub custom_themes: Option<Vec<Theme>>,
@@ -59,6 +60,7 @@ impl Config {
     fn default() -> Self {
         Self {
             theme: None,
+            default_directory: None,
             sort_preference: None,
             shortcuts: None,
             custom_themes: None,

--- a/crates/kiorg/tests/initial_path_test.rs
+++ b/crates/kiorg/tests/initial_path_test.rs
@@ -2,6 +2,25 @@ use egui::Context;
 use kiorg::Kiorg;
 use tempfile::tempdir;
 
+/// Helper to build a state.json string with a given path and restore_session value
+fn make_state_json(path: &str, restore_session: bool) -> String {
+    format!(
+        r#"{{
+        "tab_manager": {{
+            "tab_states": [
+                {{
+                    "current_path": "{path}"
+                }}
+            ],
+            "current_tab_index": 0,
+            "sort_column": "Name",
+            "sort_order": "Ascending"
+        }},
+        "restore_session": {restore_session}
+    }}"#
+    )
+}
+
 #[test]
 fn test_fallback_to_current_dir_when_saved_path_nonexistent() {
     // Create a temporary directory for testing
@@ -12,19 +31,8 @@ fn test_fallback_to_current_dir_when_saved_path_nonexistent() {
     let config_dir = test_dir_path.join("config");
     std::fs::create_dir_all(&config_dir).unwrap();
 
-    // Create a state.json file with a non-existent path
-    let state_json = r#"{
-        "tab_manager": {
-            "tab_states": [
-                {
-                    "current_path": "/path/that/does/not/exist"
-                }
-            ],
-            "current_tab_index": 0,
-            "sort_column": "Name",
-            "sort_order": "Ascending"
-        }
-    }"#;
+    // Create a state.json file with restore_session true but a non-existent path
+    let state_json = make_state_json("/path/that/does/not/exist", true);
     std::fs::write(config_dir.join("state.json"), state_json).unwrap();
 
     // Create a new egui context
@@ -48,5 +56,149 @@ fn test_fallback_to_current_dir_when_saved_path_nonexistent() {
     assert_eq!(
         current_path, expected_path,
         "App should fall back to current directory when saved path doesn't exist"
+    );
+}
+
+#[test]
+fn test_restore_session_true_restores_valid_saved_path() {
+    // Create a temporary directory for testing
+    let temp_dir = tempdir().unwrap();
+    let test_dir_path = temp_dir.path().to_path_buf();
+
+    // Create a directory to use as the saved session path
+    let saved_dir = test_dir_path.join("saved_session");
+    std::fs::create_dir_all(&saved_dir).unwrap();
+
+    // Create a config directory
+    let config_dir = test_dir_path.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    // Create a state.json file with restore_session true and a valid path
+    let state_json = make_state_json(saved_dir.to_str().unwrap(), true);
+    std::fs::write(config_dir.join("state.json"), state_json).unwrap();
+
+    // Create a new egui context
+    let ctx = Context::default();
+    let cc = eframe::CreationContext::_new_kittest(ctx);
+
+    // Create the app with the test config directory override
+    // We don't provide an initial directory, so it should restore from state.json
+    let app = Kiorg::new(&cc, None, Some(config_dir)).expect("Failed to create Kiorg app");
+
+    // The app should have restored the saved session path
+    let current_path = app.tab_manager.current_tab_ref().current_path.clone();
+    assert_eq!(
+        current_path, saved_dir,
+        "App should restore the saved session path when restore_session is true"
+    );
+}
+
+#[test]
+fn test_restore_session_false_ignores_saved_path() {
+    // Create a temporary directory for testing
+    let temp_dir = tempdir().unwrap();
+    let test_dir_path = temp_dir.path().to_path_buf();
+
+    // Create a directory to use as the saved session path
+    let saved_dir = test_dir_path.join("saved_session");
+    std::fs::create_dir_all(&saved_dir).unwrap();
+
+    // Create a config directory
+    let config_dir = test_dir_path.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    // Create a state.json file with restore_session false and a valid path
+    let state_json = make_state_json(saved_dir.to_str().unwrap(), false);
+    std::fs::write(config_dir.join("state.json"), state_json).unwrap();
+
+    // Create a new egui context
+    let ctx = Context::default();
+    let cc = eframe::CreationContext::_new_kittest(ctx);
+
+    // Create the app with the test config directory override
+    // restore_session is false, so it should NOT restore the saved path
+    let app = Kiorg::new(&cc, None, Some(config_dir)).expect("Failed to create Kiorg app");
+
+    // Check that the current path is NOT the saved session path
+    let current_path = app.tab_manager.current_tab_ref().current_path.clone();
+    assert_ne!(
+        current_path, saved_dir,
+        "App should not restore saved path when restore_session is false"
+    );
+
+    // The app should have fallen back to the home directory
+    let expected_path = dirs::home_dir().unwrap();
+    assert_eq!(
+        current_path, expected_path,
+        "App should fall back to home directory when restore_session is false"
+    );
+}
+
+#[test]
+fn test_restore_session_flag_reset_to_false_after_load() {
+    // Create a temporary directory for testing
+    let temp_dir = tempdir().unwrap();
+    let test_dir_path = temp_dir.path().to_path_buf();
+
+    // Create a directory to use as the saved session path
+    let saved_dir = test_dir_path.join("saved_session");
+    std::fs::create_dir_all(&saved_dir).unwrap();
+
+    // Create a config directory
+    let config_dir = test_dir_path.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    // Create a state.json file with restore_session true
+    let state_json = make_state_json(saved_dir.to_str().unwrap(), true);
+    std::fs::write(config_dir.join("state.json"), &state_json).unwrap();
+
+    // Create a new egui context
+    let ctx = Context::default();
+    let cc = eframe::CreationContext::_new_kittest(ctx);
+
+    // Create the app, load state and then reset the flag
+    let _app =
+        Kiorg::new(&cc, None, Some(config_dir.clone())).expect("Failed to create Kiorg app");
+
+    // After loading, the state file should have restore_session reset to false
+    let updated_json = std::fs::read_to_string(config_dir.join("state.json")).unwrap();
+    let updated_state: serde_json::Value = serde_json::from_str(&updated_json).unwrap();
+    assert_eq!(
+        updated_state["restore_session"], false,
+        "restore_session should be reset to false after loading"
+    );
+}
+
+#[test]
+fn test_no_restore_session_uses_default_directory() {
+    // Create a temporary directory for testing
+    let temp_dir = tempdir().unwrap();
+    let test_dir_path = temp_dir.path().to_path_buf();
+
+    // Create a directory to use as the default directory
+    let default_dir = test_dir_path.join("my_default");
+    std::fs::create_dir_all(&default_dir).unwrap();
+
+    // Create a config directory
+    let config_dir = test_dir_path.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    // Create a config.toml with default_directory set
+    let config_toml = format!("default_directory = \"{}\"", default_dir.to_str().unwrap());
+    std::fs::write(config_dir.join("config.toml"), config_toml).unwrap();
+
+    // Create a new egui context
+    let ctx = Context::default();
+    let cc = eframe::CreationContext::_new_kittest(ctx);
+
+    // Create the app with the test config directory override
+    // Initial directory and state.json are not provided, so it should use default_directory
+    let app = Kiorg::new(&cc, None, Some(config_dir)).expect("Failed to create Kiorg app");
+
+    // The app should have used the default_directory from config
+    let current_path = app.tab_manager.current_tab_ref().current_path.clone();
+    assert_eq!(
+        current_path, default_dir,
+        "App should use default_directory from config when no session to restore"
     );
 }

--- a/crates/kiorg/tests/initial_path_test.rs
+++ b/crates/kiorg/tests/initial_path_test.rs
@@ -4,12 +4,14 @@ use tempfile::tempdir;
 
 /// Helper to build a state.json string with a given path and restore_session value
 fn make_state_json(path: &str, restore_session: bool) -> String {
+    // Escape backslashes for JSON (Windows paths contain backslashes)
+    let escaped_path = path.replace('\\', "\\\\");
     format!(
         r#"{{
         "tab_manager": {{
             "tab_states": [
                 {{
-                    "current_path": "{path}"
+                    "current_path": "{escaped_path}"
                 }}
             ],
             "current_tab_index": 0,
@@ -183,7 +185,8 @@ fn test_no_restore_session_uses_default_directory() {
     std::fs::create_dir_all(&config_dir).unwrap();
 
     // Create a config.toml with default_directory set
-    let config_toml = format!("default_directory = \"{}\"", default_dir.to_str().unwrap());
+    let default_dir_str = default_dir.to_str().unwrap().replace('\\', "/");
+    let config_toml = format!("default_directory = \"{default_dir_str}\"");
     std::fs::write(config_dir.join("config.toml"), config_toml).unwrap();
 
     // Create a new egui context

--- a/crates/kiorg/tests/initial_path_test.rs
+++ b/crates/kiorg/tests/initial_path_test.rs
@@ -157,8 +157,7 @@ fn test_restore_session_flag_reset_to_false_after_load() {
     let cc = eframe::CreationContext::_new_kittest(ctx);
 
     // Create the app, load state and then reset the flag
-    let _app =
-        Kiorg::new(&cc, None, Some(config_dir.clone())).expect("Failed to create Kiorg app");
+    let _app = Kiorg::new(&cc, None, Some(config_dir.clone())).expect("Failed to create Kiorg app");
 
     // After loading, the state file should have restore_session reset to false
     let updated_json = std::fs::read_to_string(config_dir.join("state.json")).unwrap();


### PR DESCRIPTION
Description:
This change adds a `default_directory` config option to set a preferred starting directory when no session is restored. It also fixes a bug at launch where outdated tab_states are used.

Before change:
- Kiorg opens at the home directory when there is no saved state.
- If quit through the app (q / escape + enter on the exit confirmation), the session is saved next time Kiorg is opened.
- If a new session is started and quit using the `"x"` button or `command+q` on Mac, it does not save the new session state. As a result, the next startup opens the outdated session state.

After changes:
- Kiorg opens at `default_directory = "..."` in `config.toml` as a fallback before the home directory.
- If quit through the app (q / escape + enter on the exit confirmation), the session is saved next time Kiorg is opened.
- If a new session is started and quit using the `"x"` button or `command+q` on Mac, it does not save the new session state. `restore_session` state is marked as false, and the next startup opens the default directory (or home directory if not specified).

...

Could always save the state, but I typically use `"x"` or `command+q` when I want to delete the current session.
Also, I did not implement deleting the outdated state data because it will not be used until the user performs another state-saving quit.