### PR TITLE
add missing app id

### DIFF
--- a/crates/kiorg/src/main.rs
+++ b/crates/kiorg/src/main.rs
@@ -114,7 +114,8 @@ fn main() -> Result<(), eframe::Error> {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1280.0, 800.0])
             .with_min_inner_size([800.0, 600.0])
-            .with_icon(icon_data),
+            .with_icon(icon_data)
+            .with_app_id("kiorg"),
         ..Default::default()
     };
 


### PR DESCRIPTION
I was trying to set up window rules in niri for kiorg, but noticed that app id wasn't set. While you _can_ match rules on window titles, it's generally not best practice. 