### PR TITLE
fix: isolate pan state between different preview types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,7 +3028,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kiorg"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "ahash",
  "bytecheck",

--- a/crates/kiorg/Cargo.toml
+++ b/crates/kiorg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kiorg"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 rust-version = "1.87"
 authors = ["houqp"]

--- a/crates/kiorg/src/ui/popup/image_viewer.rs
+++ b/crates/kiorg/src/ui/popup/image_viewer.rs
@@ -88,9 +88,11 @@ pub fn render_popup(
     available_width: f32,
     available_height: f32,
 ) {
+    let source_id = egui::Id::new(&image_meta.title);
     crate::ui::preview::image::render_interactive(
         ui,
         &image_meta.image,
+        source_id,
         available_width,
         available_height,
     );

--- a/crates/kiorg/src/ui/popup/pdf_viewer.rs
+++ b/crates/kiorg/src/ui/popup/pdf_viewer.rs
@@ -222,9 +222,11 @@ pub fn render_popup(ui: &mut egui::Ui, viewer_content: &mut PdfViewerContent, co
     let remaining_width = ui.available_width();
     let remaining_height = ui.available_height();
     let pdf_image = egui::Image::new(viewer_content.meta.cover.clone());
+    let page_id = egui::Id::new(&viewer_content.meta.file_id).with(current_page);
     crate::ui::preview::image::render_interactive(
         ui,
         &pdf_image,
+        page_id,
         remaining_width,
         remaining_height,
     );

--- a/crates/kiorg/src/ui/popup/video_viewer.rs
+++ b/crates/kiorg/src/ui/popup/video_viewer.rs
@@ -58,20 +58,15 @@ impl VideoViewer {
             .max_size(popup_size)
             .min_size(popup_size)
             .open(&mut keep_open)
-            .show(ctx, |ui| {
-                let available_width = ui.available_width();
-                let available_height = ui.available_height();
-
-                match self {
-                    Self::Loaded(video_meta) => {
-                        render_popup(ui, video_meta, available_width, available_height);
-                    }
-                    Self::Loading(path, _, _cancel_sender) => {
-                        crate::ui::popup::preview::render_loading(ui, path, colors);
-                    }
-                    Self::Error(e) => {
-                        crate::ui::popup::preview::render_error(ui, e, colors);
-                    }
+            .show(ctx, |ui| match self {
+                Self::Loaded(video_meta) => {
+                    render_popup(ui, video_meta);
+                }
+                Self::Loading(path, _, _cancel_sender) => {
+                    crate::ui::popup::preview::render_loading(ui, path, colors);
+                }
+                Self::Error(e) => {
+                    crate::ui::popup::preview::render_error(ui, e, colors);
                 }
             });
 
@@ -80,16 +75,13 @@ impl VideoViewer {
 }
 
 /// Render video content optimized for popup view
-pub fn render_popup(
-    ui: &mut egui::Ui,
-    video_meta: &VideoMeta,
-    available_width: f32,
-    available_height: f32,
-) {
+pub fn render_popup(ui: &mut egui::Ui, video_meta: &VideoMeta) {
+    let source_id = egui::Id::new("video").with(&video_meta.title);
     crate::ui::preview::image::render_interactive(
         ui,
         &video_meta.thumbnail_image,
-        available_width,
-        available_height,
+        source_id,
+        ui.available_width(),
+        ui.available_height(),
     );
 }

--- a/crates/kiorg/src/ui/preview/image.rs
+++ b/crates/kiorg/src/ui/preview/image.rs
@@ -344,6 +344,7 @@ pub fn read_image_with_metadata(
 pub fn render_interactive(
     ui: &mut egui::Ui,
     image: &egui::Image<'static>,
+    source_id: egui::Id,
     available_width: f32,
     available_height: f32,
 ) {
@@ -366,7 +367,7 @@ pub fn render_interactive(
         };
 
         // Unique id for storing pan/zoom state per image
-        let id = ui.id().with("image_pan_zoom");
+        let id = ui.id().with("image_pan_zoom").with(source_id);
         let mut pan = ui.ctx().data(|d| {
             d.get_temp::<egui::Vec2>(id.with("pan"))
                 .unwrap_or(egui::Vec2::ZERO)

--- a/crates/kiorg/src/ui/preview/plugin.rs
+++ b/crates/kiorg/src/ui/preview/plugin.rs
@@ -25,9 +25,11 @@ pub fn render(
                 RenderedComponent::Image(image) => {
                     let img = &image.image;
                     if image.interactive {
+                        let source_id = egui::Id::new(&image.uid);
                         crate::ui::preview::image::render_interactive(
                             ui,
                             img,
+                            source_id,
                             available_width,
                             available_height,
                         );


### PR DESCRIPTION
…isolation

Pass an explicit egui::Id from each call site into render_interactive so that pan/zoom state is keyed per resource rather than shared globally.

- pdf_viewer: uses file_id + page index
- image_viewer: uses image title
- video_viewer: uses Id::new("video").with(title) to namespace without allocation
- plugin: uses image uid

This prevents stale zoom/pan state from leaking across different files or page transitions.